### PR TITLE
FF-168: Thrift serialization

### DIFF
--- a/apps/ff_server/src/ff_proto_utils.erl
+++ b/apps/ff_server/src/ff_proto_utils.erl
@@ -1,0 +1,71 @@
+-module(ff_proto_utils).
+
+-export([serialize/2]).
+-export([deserialize/2]).
+
+-spec serialize(thrift_type(), term()) -> binary().
+
+-type thrift_type() ::
+    thrift_base_type() |
+    thrift_collection_type() |
+    thrift_enum_type() |
+    thrift_struct_type().
+
+-type thrift_base_type() ::
+    bool   |
+    double |
+    i8     |
+    i16    |
+    i32    |
+    i64    |
+    string.
+
+-type thrift_collection_type() ::
+    {list, thrift_type()} |
+    {set, thrift_type()} |
+    {map, thrift_type(), thrift_type()}.
+
+-type thrift_enum_type() ::
+    {enum, thrift_type_ref()}.
+
+-type thrift_struct_type() ::
+    {struct, thrift_struct_flavor(), thrift_type_ref() | thrift_struct_def()}.
+
+-type thrift_struct_flavor() :: struct | union | exception.
+
+-type thrift_type_ref() :: {module(), Name :: atom()}.
+
+-type thrift_struct_def() :: list({
+    Tag :: pos_integer(),
+    Requireness :: required | optional | undefined,
+    Type :: thrift_struct_type(),
+    Name :: atom(),
+    Default :: any()
+}).
+
+serialize(Type, Data) ->
+    {ok, Trans} = thrift_membuffer_transport:new(),
+    {ok, Proto} = thrift_binary_protocol:new(Trans, [{strict_read, true}, {strict_write, true}]),
+    case thrift_protocol:write(Proto, {Type, Data}) of
+        {NewProto, ok} ->
+            {_, {ok, Result}} = thrift_protocol:close_transport(NewProto),
+            Result;
+        {_NewProto, {error, Reason}} ->
+            erlang:error({thrift, {protocol, Reason}})
+    end.
+
+-spec deserialize(thrift_type(), binary()) ->
+    term().
+
+deserialize(Type, {bin, Data}) ->
+    {ok, Trans} = thrift_membuffer_transport:new(Data),
+    {ok, Proto} = thrift_binary_protocol:new(Trans, [{strict_read, true}, {strict_write, true}]),
+    case thrift_protocol:read(Proto, Type) of
+        {_NewProto, {ok, Result}} ->
+            Result;
+        {_NewProto, {error, Reason}} ->
+            erlang:error({thrift, {protocol, Reason}})
+    end.
+
+% new_protocol(Trans) ->
+%     thrift_binary_protocol:new(Trans, [{strict_read, true}, {strict_write, true}]).

--- a/apps/fistful/src/ff_identity.erl
+++ b/apps/fistful/src/ff_identity.erl
@@ -203,7 +203,7 @@ create(ID, Party, ProviderID, ClassID, ExternalID) ->
             contract_template => ff_identity_class:contract_template(Class),
             contractor_level  => ff_identity_class:contractor_level(Level)
         })),
-        Events = [
+        wrap_events([
             {created, add_external_id(ExternalID, #{
                 id       => ID,
                 party    => Party,
@@ -216,14 +216,12 @@ create(ID, Party, ProviderID, ClassID, ExternalID) ->
             {level_changed,
                 LevelID
             }
-        ],
-        R = wrap_changes(Events),
-        R
+        ])
     end).
 
 %%
 
-wrap_changes(Events) when is_list(Events) -> % Maybe it is changes, not events?
+wrap_events(Events) when is_list(Events) -> % Maybe it is changes, not events?
     [serialize_event(ff_identity_codec:marshal(change, E)) || E <- Events].
 
 serialize_event(E) ->
@@ -233,12 +231,6 @@ serialize_event(E) ->
        format_version => 1,
        data => {bin, Bin}
     }.
-
-% wrap_event({created, Identity}) ->
-%     Idnt = ff_identity_codec:marshal_identity(Identity),
-%     {created, Idnt};
-% wrap_event({level_changed, LevelID}) ->
-%     {level_changed, LevelID}. % really?
 
 -spec start_challenge(challenge_id(), challenge_class(), [ff_identity_challenge:proof()], identity()) ->
     {ok, [event()]} |

--- a/apps/fistful/src/ff_identity.erl
+++ b/apps/fistful/src/ff_identity.erl
@@ -326,7 +326,7 @@ do_apply_event({created, Identity}, undefined) ->
 do_apply_event({level_changed, L}, Identity) ->
     Identity#{level => L};
 do_apply_event({effective_challenge_changed, ID}, Identity) ->
-    Identity#{effective_challenge => ID};
+    Identity#{effective => ID};
 do_apply_event({{challenge, ID}, Ev}, Identity) ->
     with_challenges(
         fun (Cs) ->

--- a/apps/wapi/test/wapi_SUITE.erl
+++ b/apps/wapi/test/wapi_SUITE.erl
@@ -44,25 +44,25 @@
 
 all() ->
     [ {group, default}
-    % , {group, quote}
-    % , {group, woody}
-    % , {group, errors}
-    % , {group, eventsink}
+    , {group, quote}
+    , {group, woody}
+    , {group, errors}
+    , {group, eventsink}
     ].
 
 -spec groups() -> [{group_name(), list(), [test_case_name()]}].
 
 groups() ->
     [
-        {default, [sequence, {repeat, 1}], [
-            % create_w2w_test
-            % create_destination_failed_test,
-            withdrawal_to_bank_card_test
-            % withdrawal_to_crypto_wallet_test,
-            % withdrawal_to_ripple_wallet_test,
-            % withdrawal_to_ripple_wallet_with_tag_test,
-            % unknown_withdrawal_test,
-            % get_wallet_by_external_id
+        {default, [sequence, {repeat, 2}], [
+            create_w2w_test,
+            create_destination_failed_test,
+            withdrawal_to_bank_card_test,
+            withdrawal_to_crypto_wallet_test,
+            withdrawal_to_ripple_wallet_test,
+            withdrawal_to_ripple_wallet_with_tag_test,
+            unknown_withdrawal_test,
+            get_wallet_by_external_id
         ]},
         {quote, [], [
             quote_encode_decode_test,

--- a/apps/wapi/test/wapi_SUITE.erl
+++ b/apps/wapi/test/wapi_SUITE.erl
@@ -44,25 +44,25 @@
 
 all() ->
     [ {group, default}
-    , {group, quote}
-    , {group, woody}
-    , {group, errors}
-    , {group, eventsink}
+    % , {group, quote}
+    % , {group, woody}
+    % , {group, errors}
+    % , {group, eventsink}
     ].
 
 -spec groups() -> [{group_name(), list(), [test_case_name()]}].
 
 groups() ->
     [
-        {default, [sequence, {repeat, 2}], [
-            create_w2w_test,
-            create_destination_failed_test,
-            withdrawal_to_bank_card_test,
-            withdrawal_to_crypto_wallet_test,
-            withdrawal_to_ripple_wallet_test,
-            withdrawal_to_ripple_wallet_with_tag_test,
-            unknown_withdrawal_test,
-            get_wallet_by_external_id
+        {default, [sequence, {repeat, 1}], [
+            % create_w2w_test
+            % create_destination_failed_test,
+            withdrawal_to_bank_card_test
+            % withdrawal_to_crypto_wallet_test,
+            % withdrawal_to_ripple_wallet_test,
+            % withdrawal_to_ripple_wallet_with_tag_test,
+            % unknown_withdrawal_test,
+            % get_wallet_by_external_id
         ]},
         {quote, [], [
             quote_encode_decode_test,


### PR DESCRIPTION
Попробовал реализовать сериализацию для небольшого набора сущностей (`Identity` и `Withdrawals`). Тесты и диалайзер пока БУДУТ падать