### PR TITLE
Add missing permission for GetWithdrawalByExternalID

### DIFF
--- a/apps/wapi/src/wapi_auth.erl
+++ b/apps/wapi/src/wapi_auth.erl
@@ -162,6 +162,8 @@ get_operation_access('CreateWithdrawal', _) ->
     [{[withdrawals], write}];
 get_operation_access('GetWithdrawal', _) ->
     [{[withdrawals], read}];
+get_operation_access('GetWithdrawalByExternalID', _) ->
+    [{[withdrawals], read}];
 get_operation_access('PollWithdrawalEvents', _) ->
     [{[withdrawals], read}];
 get_operation_access('GetWithdrawalEvents', _) ->


### PR DESCRIPTION
Fix for
```
{"@severity":"error","@timestamp":"2020-05-19T10:01:46.670522Z","message":"Ranch listener wapi_swagger_server, connection process <0.7666.0>, stream 1 had its request process <0.7667.0> exit with reason function_clause and stacktrace [{wapi_auth,get_operation_access,['GetWithdrawalByExternalID',#{'X-Request-Deadline' => undefined,'X-Request-ID' => <<\"e8e5ec5f-3f94174\"...>>,externalID => <<\"external_id\">>}],[{file,\"/home/jenkins/jenkins-agent/jenkins-agent/workspace/ey_private_fistful-server_master/apps/wapi/src/wapi_auth.erl\"},{line,85}]},{wapi_auth,authorize_operation,3,[{file,\"/home/jenkins/jenkins-agent/jenkins-agent/workspace/ey_private_fistful-server_master/apps/wapi/src/wapi_auth.erl\"},{line,42}]},{wapi_handler,process_request,6,[{file,\"/home/jenkins/jenkins-agent/jenkins-agent/workspace/ey_private_fistful-server_master/apps/wapi/src/wapi_handler.erl\"},{line,76}]},{swag_server_wallet_withdrawals_handler,handle_request_json,2,[{file,[...]},{line,...}]},{cowboy_rest,call,3,[{file,...},{...}]},{cowboy_rest,set_resp_body,2,[{...}|...]},{cowboy_rest,upgrade,4,[...]},{cowboy_stre..."}
```