### PR TITLE
+fix p2p_session service url

### DIFF
--- a/apps/ff_cth/src/ct_helper.erl
+++ b/apps/ff_cth/src/ct_helper.erl
@@ -130,11 +130,11 @@ start_app(wapi_woody_client = AppName) ->
             fistful_wallet => "http://localhost:8022/v1/wallet",
             fistful_identity => "http://localhost:8022/v1/identity",
             fistful_destination => "http://localhost:8022/v1/destination",
-            w2w_transfer => "http://localhost:8022/v1/w2w_transfer",
-            p2p_transfer => "http://localhost:8022/v1/p2p_transfer",
-            p2p_session => "http://localhost:8022/v1/p2p_transfer/session",
             fistful_withdrawal => "http://localhost:8022/v1/withdrawal",
-            fistful_p2p_template => "http://localhost:8022/v1/p2p_template"
+            fistful_w2w_transfer => "http://localhost:8022/v1/w2w_transfer",
+            fistful_p2p_template => "http://localhost:8022/v1/p2p_template",
+            p2p_transfer => "http://localhost:8022/v1/p2p_transfer",
+            p2p_session => "http://localhost:8022/v1/p2p_transfer/session"
         }},
         {service_retries, #{
             fistful_stat    => #{

--- a/apps/ff_cth/src/ct_helper.erl
+++ b/apps/ff_cth/src/ct_helper.erl
@@ -134,7 +134,7 @@ start_app(wapi_woody_client = AppName) ->
             fistful_w2w_transfer => "http://localhost:8022/v1/w2w_transfer",
             fistful_p2p_template => "http://localhost:8022/v1/p2p_template",
             fistful_p2p_transfer => "http://localhost:8022/v1/p2p_transfer",
-            p2p_session => "http://localhost:8022/v1/p2p_transfer/session"
+            fistful_p2p_session => "http://localhost:8022/v1/p2p_transfer/session"
         }},
         {service_retries, #{
             fistful_stat    => #{

--- a/apps/ff_cth/src/ct_helper.erl
+++ b/apps/ff_cth/src/ct_helper.erl
@@ -132,7 +132,7 @@ start_app(wapi_woody_client = AppName) ->
             fistful_destination => "http://localhost:8022/v1/destination",
             w2w_transfer => "http://localhost:8022/v1/w2w_transfer",
             p2p_transfer => "http://localhost:8022/v1/p2p_transfer",
-            p2p_session => "http://localhost:8022/v1/p2p_session",
+            p2p_session => "http://localhost:8022/v1/p2p_transfer/session",
             fistful_withdrawal => "http://localhost:8022/v1/withdrawal",
             fistful_p2p_template => "http://localhost:8022/v1/p2p_template"
         }},

--- a/apps/ff_cth/src/ct_helper.erl
+++ b/apps/ff_cth/src/ct_helper.erl
@@ -133,7 +133,7 @@ start_app(wapi_woody_client = AppName) ->
             fistful_withdrawal => "http://localhost:8022/v1/withdrawal",
             fistful_w2w_transfer => "http://localhost:8022/v1/w2w_transfer",
             fistful_p2p_template => "http://localhost:8022/v1/p2p_template",
-            p2p_transfer => "http://localhost:8022/v1/p2p_transfer",
+            fistful_p2p_transfer => "http://localhost:8022/v1/p2p_transfer",
             p2p_session => "http://localhost:8022/v1/p2p_transfer/session"
         }},
         {service_retries, #{

--- a/apps/wapi/src/wapi_access_backend.erl
+++ b/apps/wapi/src/wapi_access_backend.erl
@@ -96,7 +96,7 @@ get_context_by_id(w2w_transfer, W2WTransferID, WoodyCtx) ->
             {error, notfound}
     end;
 get_context_by_id(p2p_transfer, P2PTransferID, WoodyCtx) ->
-    Request = {p2p_transfer, 'GetContext', [P2PTransferID]},
+    Request = {fistful_p2p_transfer, 'GetContext', [P2PTransferID]},
     case wapi_handler_utils:service_call(Request, WoodyCtx) of
         {ok, Context} ->
             Context;

--- a/apps/wapi/src/wapi_access_backend.erl
+++ b/apps/wapi/src/wapi_access_backend.erl
@@ -88,7 +88,7 @@ get_context_by_id(p2p_template, TemplateID, WoodyCtx) ->
             {error, notfound}
     end;
 get_context_by_id(w2w_transfer, W2WTransferID, WoodyCtx) ->
-    Request = {w2w_transfer, 'GetContext', [W2WTransferID]},
+    Request = {fistful_w2w_transfer, 'GetContext', [W2WTransferID]},
     case wapi_handler_utils:service_call(Request, WoodyCtx) of
         {ok, Context} ->
             Context;

--- a/apps/wapi/src/wapi_p2p_transfer_backend.erl
+++ b/apps/wapi/src/wapi_p2p_transfer_backend.erl
@@ -57,7 +57,7 @@
 -define(CONTINUATION_SESSION, <<"p2p_session_event_id">>).
 
 -type event() :: #p2p_transfer_Event{} | #p2p_session_Event{}.
--type event_service() :: fistful_p2p_transfer | p2p_session.
+-type event_service() :: fistful_p2p_transfer | fistful_p2p_session.
 -type event_range() :: #'EventRange'{}.
 -type event_id() :: ff_proto_base_thrift:'EventID'() | undefined.
 
@@ -244,7 +244,7 @@ do_get_events(ID, Token, HandlerContext) ->
         )),
 
         {SessionEvents, SessionCursor}  = unwrap(events_collect(
-            p2p_session,
+            fistful_p2p_session,
             SessionID,
             events_range(PrevSessionCursor),
             HandlerContext,
@@ -317,7 +317,7 @@ continuation_token_cursor(p2p_session, DecodedToken) ->
         Acc0 :: [] | [event()],
         Acc1 :: [] | [event()].
 
-events_collect(p2p_session, undefined, #'EventRange'{'after' = Cursor}, _HandlerContext, Acc) ->
+events_collect(fistful_p2p_session, undefined, #'EventRange'{'after' = Cursor}, _HandlerContext, Acc) ->
     % no session ID is not an error
     {ok, {Acc, Cursor}};
 events_collect(_EventService, _EntityID, #'EventRange'{'after' = Cursor, 'limit' = Limit}, _HandlerContext, Acc)
@@ -915,7 +915,7 @@ events_collect_test_() ->
         fun({Collect, Event}) ->
             [
                 % SessionID undefined is not an error
-                Collect(p2p_session, undefined, events_range(1),  [Event(0)],
+                Collect(fistful_p2p_session, undefined, events_range(1),  [Event(0)],
                     {ok, {[Event(0)], 1}}
                 ),
                 % Limit < 0 < undefined

--- a/apps/wapi/src/wapi_p2p_transfer_backend.erl
+++ b/apps/wapi/src/wapi_p2p_transfer_backend.erl
@@ -251,6 +251,7 @@ do_get_events(ID, Token, HandlerContext) ->
             []
         )),
 
+
         NewTransferCursor = events_max(PrevTransferCursor, TransferCursor),
         NewSessionCursor = events_max(PrevSessionCursor, SessionCursor),
         NewToken = unwrap(continuation_token_pack(NewTransferCursor, NewSessionCursor, PartyID)),
@@ -447,23 +448,27 @@ marshal_transfer_params(#{
 
 marshal_sender(#{
     <<"token">> := Token,
+    <<"authData">> := AuthData,
     <<"contactInfo">> := ContactInfo
 }) ->
-    Resource = case wapi_crypto:decrypt_bankcard_token(Token) of
+    ResourceBankCard = case wapi_crypto:decrypt_bankcard_token(Token) of
         unrecognized ->
             BankCard = wapi_utils:base64url_to_map(Token),
-            {bank_card, #'ResourceBankCard'{
+            #'ResourceBankCard'{
                 bank_card = #'BankCard'{
                     token      = maps:get(<<"token">>, BankCard),
                     bin        = maps:get(<<"bin">>, BankCard),
                     masked_pan = maps:get(<<"lastDigits">>, BankCard)
                 }
-            }};
+            };
         {ok, BankCard} ->
-            {bank_card, #'ResourceBankCard'{bank_card = BankCard}}
+            #'ResourceBankCard'{bank_card = BankCard}
     end,
+    ResourceBankCardAuth = ResourceBankCard#'ResourceBankCard'{
+        auth_data = {session_data, #'SessionAuthData'{id = AuthData}}
+    },
     {resource, #p2p_transfer_RawResource{
-        resource = Resource,
+        resource = {bank_card, ResourceBankCardAuth},
         contact_info = marshal_contact_info(ContactInfo)
     }}.
 

--- a/apps/wapi/src/wapi_p2p_transfer_backend.erl
+++ b/apps/wapi/src/wapi_p2p_transfer_backend.erl
@@ -251,7 +251,6 @@ do_get_events(ID, Token, HandlerContext) ->
             []
         )),
 
-
         NewTransferCursor = events_max(PrevTransferCursor, TransferCursor),
         NewSessionCursor = events_max(PrevSessionCursor, SessionCursor),
         NewToken = unwrap(continuation_token_pack(NewTransferCursor, NewSessionCursor, PartyID)),

--- a/apps/wapi/src/wapi_w2w_backend.erl
+++ b/apps/wapi/src/wapi_w2w_backend.erl
@@ -39,7 +39,7 @@ create_transfer(Params = #{<<"sender">> := SenderID}, HandlerContext) ->
 
 create_transfer(ID, Params, Context, HandlerContext) ->
     TransferParams = marshal(transfer_params, Params#{<<"id">> => ID}),
-    Request = {w2w_transfer, 'Create', [TransferParams, marshal(context, Context)]},
+    Request = {fistful_w2w_transfer, 'Create', [TransferParams, marshal(context, Context)]},
     case service_call(Request, HandlerContext) of
         {ok, Transfer} ->
             {ok, unmarshal(transfer, Transfer)};
@@ -64,7 +64,7 @@ when
 
 get_transfer(ID, HandlerContext) ->
     EventRange = #'EventRange'{},
-    Request = {w2w_transfer, 'Get', [ID, EventRange]},
+    Request = {fistful_w2w_transfer, 'Get', [ID, EventRange]},
     case service_call(Request, HandlerContext) of
         {ok, TransferThrift} ->
             case wapi_access_backend:check_resource(w2w_transfer, TransferThrift, HandlerContext) of

--- a/apps/wapi/test/wapi_p2p_transfer_tests_SUITE.erl
+++ b/apps/wapi/test/wapi_p2p_transfer_tests_SUITE.erl
@@ -471,7 +471,7 @@ get_events_ok(C) ->
             ('GetEvents', [_ID, #'EventRange'{limit = Limit}]) ->
                 {ok, [?P2P_TRANSFER_EVENT(EventID) || EventID <- lists:seq(1, Limit)]}
         end},
-        {p2p_session, fun('GetEvents', [_ID, #'EventRange'{limit = Limit}]) ->
+        {fistful_p2p_session, fun('GetEvents', [_ID, #'EventRange'{limit = Limit}]) ->
             {ok, [?P2P_SESSION_EVENT(EventID) || EventID <- lists:seq(1, Limit)]}
         end}
     ], C),

--- a/apps/wapi/test/wapi_p2p_transfer_tests_SUITE.erl
+++ b/apps/wapi/test/wapi_p2p_transfer_tests_SUITE.erl
@@ -286,8 +286,10 @@ create_with_quote_token_ok_test(C) ->
         {bender_thrift, fun('GenerateID', _) -> {ok, ?GENERATE_ID_RESULT} end},
         {fistful_identity, fun('Get', _) -> {ok, ?IDENTITY(PartyID)};
                               ('GetContext', _) -> {ok, ?DEFAULT_CONTEXT(PartyID)} end},
-        {p2p_transfer, fun('GetQuote', _) -> {ok, ?P2P_TRANSFER_QUOTE(IdentityID)};
-                          ('Create', _) -> {ok, ?P2P_TRANSFER(PartyID)} end}
+        {fistful_p2p_transfer, fun
+            ('GetQuote', _) -> {ok, ?P2P_TRANSFER_QUOTE(IdentityID)};
+            ('Create', _) -> {ok, ?P2P_TRANSFER(PartyID)}
+        end}
     ], C),
     SenderToken   = store_bank_card(C, <<"4150399999000900">>, <<"12/2025">>, <<"Buka Bjaka">>),
     ReceiverToken = store_bank_card(C, <<"4150399999000900">>, <<"12/2025">>, <<"Buka Bjaka">>),
@@ -463,7 +465,7 @@ get_fail_p2p_notfound_test(C) ->
 get_events_ok(C) ->
     PartyID = ?config(party, C),
     wapi_ct_helper:mock_services([
-        {p2p_transfer, fun
+        {fistful_p2p_transfer, fun
             ('GetContext', _) -> {ok, ?DEFAULT_CONTEXT(PartyID)};
             ('Get', _) -> {ok, ?P2P_TRANSFER_SESSIONS(PartyID)};
             ('GetEvents', [_ID, #'EventRange'{limit = Limit}]) ->
@@ -486,7 +488,7 @@ get_events_ok(C) ->
 get_events_fail(C) ->
     PartyID = ?config(party, C),
     wapi_ct_helper:mock_services([
-        {p2p_transfer, fun
+        {fistful_p2p_transfer, fun
             ('GetContext', _) -> {ok, ?DEFAULT_CONTEXT(PartyID)};
             ('Get', _) -> throw(#fistful_P2PNotFound{})
         end}
@@ -594,7 +596,7 @@ create_ok_start_mocks(C, ContextPartyID) ->
         {bender_thrift, fun('GenerateID', _) -> {ok, ?GENERATE_ID_RESULT} end},
         {fistful_identity, fun('Get', _) -> {ok, ?IDENTITY(PartyID)};
                               ('GetContext', _) -> {ok, ?DEFAULT_CONTEXT(ContextPartyID)} end},
-        {p2p_transfer, fun('Create', _) -> {ok, ?P2P_TRANSFER(PartyID)} end}
+        {fistful_p2p_transfer, fun('Create', _) -> {ok, ?P2P_TRANSFER(PartyID)} end}
     ], C).
 
 create_fail_start_mocks(C, CreateResultFun) ->
@@ -606,7 +608,7 @@ create_fail_start_mocks(C, ContextPartyID, CreateResultFun) ->
         {bender_thrift, fun('GenerateID', _) -> {ok, ?GENERATE_ID_RESULT} end},
         {fistful_identity, fun('Get', _) -> {ok, ?IDENTITY(PartyID)};
                               ('GetContext', _) -> {ok, ?DEFAULT_CONTEXT(ContextPartyID)} end},
-        {p2p_transfer, fun('Create', _) -> CreateResultFun() end}
+        {fistful_p2p_transfer, fun('Create', _) -> CreateResultFun() end}
     ], C).
 
 get_quote_start_mocks(C, GetQuoteResultFun) ->
@@ -614,12 +616,12 @@ get_quote_start_mocks(C, GetQuoteResultFun) ->
     wapi_ct_helper:mock_services([
         {fistful_identity, fun('Get', _) -> {ok, ?IDENTITY(PartyID)};
                               ('GetContext', _) -> {ok, ?DEFAULT_CONTEXT(PartyID)} end},
-        {p2p_transfer, fun('GetQuote', _) -> GetQuoteResultFun() end}
+        {fistful_p2p_transfer, fun('GetQuote', _) -> GetQuoteResultFun() end}
     ], C).
 
 get_start_mocks(C, GetResultFun) ->
     wapi_ct_helper:mock_services([
-        {p2p_transfer, fun('Get', _) -> GetResultFun() end}
+        {fistful_p2p_transfer, fun('Get', _) -> GetResultFun() end}
     ], C).
 
 store_bank_card(C, Pan, ExpDate, CardHolder) ->

--- a/apps/wapi/test/wapi_thrift_SUITE.erl
+++ b/apps/wapi/test/wapi_thrift_SUITE.erl
@@ -560,8 +560,7 @@ await_p2p_transfer(P2PTransferID, C) ->
             Reply = get_p2p_transfer(P2PTransferID, C),
             #{<<"status">> := #{<<"status">> := Status}} = Reply,
             Status
-        end,
-        genlib_retry:linear(3, 1000)
+        end
     ),
     ok.
 

--- a/apps/wapi/test/wapi_thrift_SUITE.erl
+++ b/apps/wapi/test/wapi_thrift_SUITE.erl
@@ -756,7 +756,7 @@ call_p2p_template_transfer(P2PTemplateID, TemplateTicket, QuoteToken, C) ->
                     <<"token">> => Token
                 },
                 <<"body">> => #{
-                    <<"amount">> => 101,
+                    <<"amount">> => ?INTEGER,
                     <<"currency">> => ?RUB
                 },
                 <<"contactInfo">> => #{

--- a/apps/wapi/test/wapi_thrift_SUITE.erl
+++ b/apps/wapi/test/wapi_thrift_SUITE.erl
@@ -561,7 +561,7 @@ await_p2p_transfer(P2PTransferID, C) ->
             #{<<"status">> := #{<<"status">> := Status}} = Reply,
             Status
         end,
-        genlib_retry:linear(6, 1000)
+        genlib_retry:linear(3, 1000)
     ),
     ok.
 

--- a/apps/wapi/test/wapi_w2w_tests_SUITE.erl
+++ b/apps/wapi/test/wapi_w2w_tests_SUITE.erl
@@ -155,7 +155,7 @@ create_fail_unauthorized_wallet_test(C) ->
     wapi_ct_helper:mock_services([
         {bender_thrift, fun('GenerateID', _) -> {ok, ?GENERATE_ID_RESULT} end},
         {fistful_wallet, fun('GetContext', _) -> {ok, ?DEFAULT_CONTEXT(<<"someotherparty">>)} end},
-        {w2w_transfer, fun('Create', _) -> {ok, ?W2W_TRANSFER(PartyID)} end}
+        {fistful_w2w_transfer, fun('Create', _) -> {ok, ?W2W_TRANSFER(PartyID)} end}
     ], C),
     ?assertEqual(
         {error, {422, #{<<"message">> => <<"No such wallet sender">>}}},
@@ -295,11 +295,11 @@ create_w2_w_transfer_start_mocks(C, CreateResultFun) ->
     wapi_ct_helper:mock_services([
         {bender_thrift, fun('GenerateID', _) -> {ok, ?GENERATE_ID_RESULT} end},
         {fistful_wallet, fun('GetContext', _) -> {ok, ?DEFAULT_CONTEXT(PartyID)} end},
-        {w2w_transfer, fun('Create', _) -> CreateResultFun() end}
+        {fistful_w2w_transfer, fun('Create', _) -> CreateResultFun() end}
     ], C).
 
 get_w2_w_transfer_start_mocks(C, GetResultFun) ->
     wapi_ct_helper:mock_services([
-        {w2w_transfer, fun('Get', _) -> GetResultFun() end}
+        {fistful_w2w_transfer, fun('Get', _) -> GetResultFun() end}
     ], C).
 

--- a/apps/wapi_woody_client/src/wapi_woody_client.erl
+++ b/apps/wapi_woody_client/src/wapi_woody_client.erl
@@ -100,7 +100,7 @@ get_service_modname(p2p_transfer) ->
     {ff_proto_p2p_transfer_thrift, 'Management'};
 get_service_modname(p2p_session) ->
     {ff_proto_p2p_session_thrift, 'Management'};
-get_service_modname(w2w_transfer) ->
+get_service_modname(fistful_w2w_transfer) ->
     {ff_proto_w2w_transfer_thrift, 'Management'}.
 
 -spec get_service_deadline(service_name()) -> undefined | woody_deadline:deadline().

--- a/apps/wapi_woody_client/src/wapi_woody_client.erl
+++ b/apps/wapi_woody_client/src/wapi_woody_client.erl
@@ -96,7 +96,7 @@ get_service_modname(fistful_p2p_template) ->
     {ff_proto_p2p_template_thrift, 'Management'};
 get_service_modname(webhook_manager) ->
     {ff_proto_webhooker_thrift, 'WebhookManager'};
-get_service_modname(p2p_transfer) ->
+get_service_modname(fistful_p2p_transfer) ->
     {ff_proto_p2p_transfer_thrift, 'Management'};
 get_service_modname(p2p_session) ->
     {ff_proto_p2p_session_thrift, 'Management'};

--- a/apps/wapi_woody_client/src/wapi_woody_client.erl
+++ b/apps/wapi_woody_client/src/wapi_woody_client.erl
@@ -98,7 +98,7 @@ get_service_modname(webhook_manager) ->
     {ff_proto_webhooker_thrift, 'WebhookManager'};
 get_service_modname(fistful_p2p_transfer) ->
     {ff_proto_p2p_transfer_thrift, 'Management'};
-get_service_modname(p2p_session) ->
+get_service_modname(fistful_p2p_session) ->
     {ff_proto_p2p_session_thrift, 'Management'};
 get_service_modname(fistful_w2w_transfer) ->
     {ff_proto_w2w_transfer_thrift, 'Management'}.

--- a/config/sys.config
+++ b/config/sys.config
@@ -154,12 +154,18 @@
 
     {wapi_woody_client, [
         {service_urls, #{
-            webhook_manager     => "http://hooker:8022/hook",
-            cds_storage         => "http://cds:8022/v1/storage",
-            identdoc_storage    => "http://cds:8022/v1/identity_document_storage",
-            fistful_stat        => "http://fistful-magista:8022/stat",
-            p2p_transfer        => "http://fistful:8022/v1/p2p_transfer",
-            p2p_session         => "http://fistful:8022/v1/p2p_transfer/session"
+            webhook_manager         => "http://hooker:8022/hook",
+            cds_storage             => "http://cds:8022/v1/storage",
+            identdoc_storage        => "http://cds:8022/v1/identity_document_storage",
+            fistful_stat            => "http://fistful-magista:8022/stat",
+            fistful_wallet          => "http://fistful:8022/v1/wallet",
+            fistful_identity        => "http://fistful:8022/v1/identity",
+            fistful_destination     => "http://fistful:8022/v1/destination",
+            fistful_withdrawal      => "http://fistful:8022/v1/withdrawal",
+            fistful_w2w_transfer    => "http://fistful:8022/v1/w2w_transfer",
+            fistful_p2p_template    => "http://fistful:8022/v1/p2p_template",
+            fistful_p2p_transfer    => "http://fistful:8022/v1/p2p_transfer",
+            fistful_p2p_session     => "http://fistful:8022/v1/p2p_transfer/session"
         }},
         {api_deadlines, #{
             wallet   => 5000 % millisec

--- a/config/sys.config
+++ b/config/sys.config
@@ -157,7 +157,9 @@
             webhook_manager     => "http://hooker:8022/hook",
             cds_storage         => "http://cds:8022/v1/storage",
             identdoc_storage    => "http://cds:8022/v1/identity_document_storage",
-            fistful_stat        => "http://fistful-magista:8022/stat"
+            fistful_stat        => "http://fistful-magista:8022/stat",
+            p2p_transfer        => "http://fistful:8022/v1/p2p_transfer",
+            p2p_session         => "http://fistful:8022/v1/p2p_transfer/session"
         }},
         {api_deadlines, #{
             wallet   => 5000 % millisec


### PR DESCRIPTION
+ верно задан образец service_url для p2p_session
+ устранена ошибка потери authData в p2p_transfe&p2p_template при передаче в thrift
+ добавлено ожидание завершения перевода в p2p_transfer test
+ добавлено ожидание завершения перевода в p2p_template test 
+ удален странный набор настроек get_default_termset из wapi_thrift_SUITE
+ имена сервисов p2p_transfer, p2p_session, w2w_transfer приведены к виду fistful_*

